### PR TITLE
Update wasmate.py to handle explicit push operands.

### DIFF
--- a/prototype-wasmate/test/call.s
+++ b/prototype-wasmate/test/call.s
@@ -5,7 +5,7 @@
 call_i32_nullary:
 	.result i32
 	.local i32
-	call $i32_nullary
+	call $i32_nullary, push
 	set_local 0, pop
 	return (get_local 0)
 func_end0:
@@ -16,7 +16,7 @@ func_end0:
 call_i64_nullary:
 	.result i64
 	.local i64
-	call $i64_nullary
+	call $i64_nullary, push
 	set_local 0, pop
 	return (get_local 0)
 func_end1:
@@ -27,7 +27,7 @@ func_end1:
 call_float_nullary:
 	.result f32
 	.local f32
-	call $float_nullary
+	call $float_nullary, push
 	set_local 0, pop
 	return (get_local 0)
 func_end2:
@@ -38,7 +38,7 @@ func_end2:
 call_double_nullary:
 	.result f64
 	.local f64
-	call $double_nullary
+	call $double_nullary, push
 	set_local 0, pop
 	return (get_local 0)
 func_end3:
@@ -58,9 +58,9 @@ call_i32_unary:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	call $i32_unary, (get_local 1)
+	call $i32_unary, push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end5:
@@ -73,11 +73,11 @@ call_i32_binary:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	call $i32_binary, (get_local 3), (get_local 2)
+	call $i32_binary, push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -88,7 +88,7 @@ func_end6:
 call_indirect_void:
 	.param i32
 	.local i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
 	void.call_indirect (get_local 1)
 	return
@@ -101,9 +101,9 @@ call_indirect_i32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.call_indirect (get_local 1)
+	i32.call_indirect (get_local 1), push
 	set_local 2, pop
 	return (get_local 2)
 func_end8:

--- a/prototype-wasmate/test/cfg-stackify.s
+++ b/prototype-wasmate/test/cfg-stackify.s
@@ -6,18 +6,18 @@ test0:
 	.param i32
 	.local i32, i32, i32, i32, i32, i32, i32
 	block $BB0_3
-	i32.const 0
+	i32.const push, 0
 	set_local 7, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.const 1
+	i32.const push, 1
 	set_local 5, pop
 BB0_1:
 	loop $BB0_3
 	block $BB0_2
-	i32.add (get_local 7), (get_local 5)
+	i32.add push, (get_local 7), (get_local 5)
 	set_local 7, pop
-	i32.lt_s (get_local 7), (get_local 3)
+	i32.lt_s push, (get_local 7), (get_local 3)
 	set_local 6, pop
 	br_if $BB0_2, (get_local 6)
 	br $BB0_3
@@ -35,18 +35,18 @@ test1:
 	.param i32
 	.local i32, i32, i32, i32, i32, i32, i32
 	block $BB1_3
-	i32.const 0
+	i32.const push, 0
 	set_local 7, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.const 1
+	i32.const push, 1
 	set_local 5, pop
 BB1_1:
 	loop $BB1_3
 	block $BB1_2
-	i32.add (get_local 7), (get_local 5)
+	i32.add push, (get_local 7), (get_local 5)
 	set_local 7, pop
-	i32.lt_s (get_local 7), (get_local 3)
+	i32.lt_s push, (get_local 7), (get_local 3)
 	set_local 6, pop
 	br_if $BB1_2, (get_local 6)
 	br $BB1_3
@@ -65,35 +65,35 @@ test2:
 	.param i32
 	.local i32, i32, i32, i32, i32, i32, i32, i32, f64, f64, f64, i32, i32, i32, i32, i32, i32
 	block $BB2_2
-	get_local 1
+	get_local push, 1
 	set_local 18, pop
-	get_local 0
+	get_local push, 0
 	set_local 17, pop
-	i32.const 1
+	i32.const push, 1
 	set_local 8, pop
-	i32.lt_s (get_local 18), (get_local 8)
+	i32.lt_s push, (get_local 18), (get_local 8)
 	set_local 9, pop
 	br_if $BB2_2, (get_local 9)
 BB2_1:
 	loop $BB2_2
-	f64.load (get_local 17)
+	f64.load push, (get_local 17)
 	set_local 10, pop
-	f64.const 0x1.999999999999ap1
+	f64.const push, 0x1.999999999999ap1
 	set_local 11, pop
-	f64.mul (get_local 10), (get_local 11)
+	f64.mul push, (get_local 10), (get_local 11)
 	set_local 12, pop
 	f64.store (get_local 17), (get_local 12)
-	i32.const -1
+	i32.const push, -1
 	set_local 13, pop
-	i32.add (get_local 18), (get_local 13)
+	i32.add push, (get_local 18), (get_local 13)
 	set_local 18, pop
-	i32.const 8
+	i32.const push, 8
 	set_local 14, pop
-	i32.add (get_local 17), (get_local 14)
+	i32.add push, (get_local 17), (get_local 14)
 	set_local 17, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 15, pop
-	i32.ne (get_local 18), (get_local 15)
+	i32.ne push, (get_local 18), (get_local 15)
 	set_local 16, pop
 	br_if $BB2_1, (get_local 16)
 BB2_2:
@@ -112,39 +112,39 @@ doublediamond:
 	block $BB3_5
 	block $BB3_4
 	block $BB3_2
-	get_local 2
+	get_local push, 2
 	set_local 4, pop
-	get_local 0
+	get_local push, 0
 	set_local 5, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 6, pop
 	i32.store (get_local 4), (get_local 6)
-	i32.ne (get_local 5), (get_local 6)
+	i32.ne push, (get_local 5), (get_local 6)
 	set_local 7, pop
 	br_if $BB3_2, (get_local 7)
-	i32.const 1
+	i32.const push, 1
 	set_local 13, pop
 	i32.store (get_local 4), (get_local 13)
 	br $BB3_5
 BB3_2:
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i32.const 2
+	i32.const push, 2
 	set_local 8, pop
 	i32.store (get_local 4), (get_local 8)
-	i32.ne (get_local 3), (get_local 6)
+	i32.ne push, (get_local 3), (get_local 6)
 	set_local 10, pop
 	br_if $BB3_4, (get_local 10)
-	i32.const 3
+	i32.const push, 3
 	set_local 12, pop
 	i32.store (get_local 4), (get_local 12)
 	br $BB3_5
 BB3_4:
-	i32.const 4
+	i32.const push, 4
 	set_local 11, pop
 	i32.store (get_local 4), (get_local 11)
 BB3_5:
-	i32.const 5
+	i32.const push, 5
 	set_local 14, pop
 	i32.store (get_local 4), (get_local 14)
 	return (get_local 6)
@@ -159,21 +159,21 @@ triangle:
 	.result i32
 	.local i32, i32, i32, i32, i32, i32, i32
 	block $BB4_2
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 4, pop
 	i32.store (get_local 2), (get_local 4)
-	i32.ne (get_local 3), (get_local 4)
+	i32.ne push, (get_local 3), (get_local 4)
 	set_local 5, pop
 	br_if $BB4_2, (get_local 5)
-	i32.const 1
+	i32.const push, 1
 	set_local 6, pop
 	i32.store (get_local 2), (get_local 6)
 BB4_2:
-	i32.const 2
+	i32.const push, 2
 	set_local 7, pop
 	i32.store (get_local 2), (get_local 7)
 	return (get_local 4)
@@ -189,26 +189,26 @@ diamond:
 	.local i32, i32, i32, i32, i32, i32, i32, i32
 	block $BB5_3
 	block $BB5_2
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 4, pop
 	i32.store (get_local 2), (get_local 4)
-	i32.ne (get_local 3), (get_local 4)
+	i32.ne push, (get_local 3), (get_local 4)
 	set_local 5, pop
 	br_if $BB5_2, (get_local 5)
-	i32.const 1
+	i32.const push, 1
 	set_local 7, pop
 	i32.store (get_local 2), (get_local 7)
 	br $BB5_3
 BB5_2:
-	i32.const 2
+	i32.const push, 2
 	set_local 6, pop
 	i32.store (get_local 2), (get_local 6)
 BB5_3:
-	i32.const 3
+	i32.const push, 3
 	set_local 8, pop
 	i32.store (get_local 2), (get_local 8)
 	return (get_local 4)
@@ -221,9 +221,9 @@ single_block:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 2, pop
 	i32.store (get_local 1), (get_local 2)
 	return (get_local 2)
@@ -236,12 +236,12 @@ minimal_loop:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 2, pop
 	i32.store (get_local 1), (get_local 2)
-	i32.const 1
+	i32.const push, 1
 	set_local 3, pop
 BB7_1:
 	loop $BB7_2
@@ -257,22 +257,22 @@ simple_loop:
 	.param i32
 	.result i32
 	.local i32, i32, i32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 4, pop
 	i32.store (get_local 2), (get_local 4)
-	i32.eq (get_local 3), (get_local 4)
+	i32.eq push, (get_local 3), (get_local 4)
 	set_local 6, pop
-	i32.const 1
+	i32.const push, 1
 	set_local 7, pop
 BB8_1:
 	loop $BB8_2
 	i32.store (get_local 2), (get_local 7)
 	br_if $BB8_1, (get_local 6)
-	i32.const 2
+	i32.const push, 2
 	set_local 8, pop
 	i32.store (get_local 2), (get_local 8)
 	return (get_local 4)
@@ -289,33 +289,33 @@ doubletriangle:
 	.local i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 	block $BB9_4
 	block $BB9_3
-	get_local 2
+	get_local push, 2
 	set_local 4, pop
-	get_local 0
+	get_local push, 0
 	set_local 5, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 6, pop
 	i32.store (get_local 4), (get_local 6)
-	i32.ne (get_local 5), (get_local 6)
+	i32.ne push, (get_local 5), (get_local 6)
 	set_local 7, pop
 	br_if $BB9_4, (get_local 7)
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i32.const 2
+	i32.const push, 2
 	set_local 8, pop
 	i32.store (get_local 4), (get_local 8)
-	i32.ne (get_local 3), (get_local 6)
+	i32.ne push, (get_local 3), (get_local 6)
 	set_local 10, pop
 	br_if $BB9_3, (get_local 10)
-	i32.const 3
+	i32.const push, 3
 	set_local 11, pop
 	i32.store (get_local 4), (get_local 11)
 BB9_3:
-	i32.const 4
+	i32.const push, 4
 	set_local 12, pop
 	i32.store (get_local 4), (get_local 12)
 BB9_4:
-	i32.const 5
+	i32.const push, 5
 	set_local 13, pop
 	i32.store (get_local 4), (get_local 13)
 	return (get_local 6)
@@ -332,34 +332,34 @@ ifelse_earlyexits:
 	.local i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 	block $BB10_4
 	block $BB10_2
-	get_local 2
+	get_local push, 2
 	set_local 4, pop
-	get_local 0
+	get_local push, 0
 	set_local 5, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 6, pop
 	i32.store (get_local 4), (get_local 6)
-	i32.ne (get_local 5), (get_local 6)
+	i32.ne push, (get_local 5), (get_local 6)
 	set_local 7, pop
 	br_if $BB10_2, (get_local 7)
-	i32.const 1
+	i32.const push, 1
 	set_local 12, pop
 	i32.store (get_local 4), (get_local 12)
 	br $BB10_4
 BB10_2:
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i32.const 2
+	i32.const push, 2
 	set_local 8, pop
 	i32.store (get_local 4), (get_local 8)
-	i32.ne (get_local 3), (get_local 6)
+	i32.ne push, (get_local 3), (get_local 6)
 	set_local 10, pop
 	br_if $BB10_4, (get_local 10)
-	i32.const 3
+	i32.const push, 3
 	set_local 11, pop
 	i32.store (get_local 4), (get_local 11)
 BB10_4:
-	i32.const 4
+	i32.const push, 4
 	set_local 13, pop
 	i32.store (get_local 4), (get_local 13)
 	return (get_local 6)
@@ -372,9 +372,9 @@ test3:
 	.param i32
 	.local i32, i32, i32, i32, i32, i32, i32
 	block $BB11_1
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 2, pop
 	br_if $BB11_1, (get_local 2)
 	br $BB11_2
@@ -384,11 +384,11 @@ BB11_2:
 	loop $BB11_5
 	block $BB11_4
 	block $BB11_2
-	i32.eq (get_local 5), (get_local 2)
+	i32.eq push, (get_local 5), (get_local 2)
 	set_local 4, pop
 BB11_3:
 	loop $BB11_4
-	i32.eq (get_local 7), (get_local 1)
+	i32.eq push, (get_local 7), (get_local 1)
 	set_local 6, pop
 	br_if $BB11_4, (get_local 6)
 	br $BB11_3

--- a/prototype-wasmate/test/comparisons_f32.s
+++ b/prototype-wasmate/test/comparisons_f32.s
@@ -7,15 +7,15 @@ ord_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	f32.eq (get_local 3), (get_local 3)
+	f32.eq push, (get_local 3), (get_local 3)
 	set_local 4, pop
-	f32.eq (get_local 2), (get_local 2)
+	f32.eq push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	i32.and (get_local 5), (get_local 4)
+	i32.and push, (get_local 5), (get_local 4)
 	set_local 6, pop
 	return (get_local 6)
 func_end0:
@@ -28,15 +28,15 @@ uno_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	f32.ne (get_local 3), (get_local 3)
+	f32.ne push, (get_local 3), (get_local 3)
 	set_local 4, pop
-	f32.ne (get_local 2), (get_local 2)
+	f32.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	i32.or (get_local 5), (get_local 4)
+	i32.or push, (get_local 5), (get_local 4)
 	set_local 6, pop
 	return (get_local 6)
 func_end1:
@@ -49,11 +49,11 @@ oeq_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.eq (get_local 3), (get_local 2)
+	f32.eq push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -66,11 +66,11 @@ une_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.ne (get_local 3), (get_local 2)
+	f32.ne push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -83,11 +83,11 @@ olt_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.lt (get_local 3), (get_local 2)
+	f32.lt push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end4:
@@ -100,11 +100,11 @@ ole_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.le (get_local 3), (get_local 2)
+	f32.le push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end5:
@@ -117,11 +117,11 @@ ogt_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.gt (get_local 3), (get_local 2)
+	f32.gt push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -134,11 +134,11 @@ oge_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.ge (get_local 3), (get_local 2)
+	f32.ge push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end7:
@@ -151,19 +151,19 @@ ueq_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.eq (get_local 3), (get_local 2)
+	f32.eq push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f32.ne (get_local 2), (get_local 2)
+	f32.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f32.ne (get_local 3), (get_local 3)
+	f32.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end8:
@@ -176,19 +176,19 @@ one_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.ne (get_local 3), (get_local 2)
+	f32.ne push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f32.eq (get_local 2), (get_local 2)
+	f32.eq push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f32.eq (get_local 3), (get_local 3)
+	f32.eq push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.and (get_local 6), (get_local 5)
+	i32.and push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.and (get_local 4), (get_local 7)
+	i32.and push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end9:
@@ -201,19 +201,19 @@ ult_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.lt (get_local 3), (get_local 2)
+	f32.lt push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f32.ne (get_local 2), (get_local 2)
+	f32.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f32.ne (get_local 3), (get_local 3)
+	f32.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end10:
@@ -226,19 +226,19 @@ ule_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.le (get_local 3), (get_local 2)
+	f32.le push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f32.ne (get_local 2), (get_local 2)
+	f32.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f32.ne (get_local 3), (get_local 3)
+	f32.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end11:
@@ -251,19 +251,19 @@ ugt_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.gt (get_local 3), (get_local 2)
+	f32.gt push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f32.ne (get_local 2), (get_local 2)
+	f32.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f32.ne (get_local 3), (get_local 3)
+	f32.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end12:
@@ -276,19 +276,19 @@ uge_f32:
 	.param f32
 	.result i32
 	.local f32, f32, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.ge (get_local 3), (get_local 2)
+	f32.ge push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f32.ne (get_local 2), (get_local 2)
+	f32.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f32.ne (get_local 3), (get_local 3)
+	f32.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end13:

--- a/prototype-wasmate/test/comparisons_f64.s
+++ b/prototype-wasmate/test/comparisons_f64.s
@@ -7,15 +7,15 @@ ord_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	f64.eq (get_local 3), (get_local 3)
+	f64.eq push, (get_local 3), (get_local 3)
 	set_local 4, pop
-	f64.eq (get_local 2), (get_local 2)
+	f64.eq push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	i32.and (get_local 5), (get_local 4)
+	i32.and push, (get_local 5), (get_local 4)
 	set_local 6, pop
 	return (get_local 6)
 func_end0:
@@ -28,15 +28,15 @@ uno_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	f64.ne (get_local 3), (get_local 3)
+	f64.ne push, (get_local 3), (get_local 3)
 	set_local 4, pop
-	f64.ne (get_local 2), (get_local 2)
+	f64.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	i32.or (get_local 5), (get_local 4)
+	i32.or push, (get_local 5), (get_local 4)
 	set_local 6, pop
 	return (get_local 6)
 func_end1:
@@ -49,11 +49,11 @@ oeq_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.eq (get_local 3), (get_local 2)
+	f64.eq push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -66,11 +66,11 @@ une_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.ne (get_local 3), (get_local 2)
+	f64.ne push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -83,11 +83,11 @@ olt_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.lt (get_local 3), (get_local 2)
+	f64.lt push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end4:
@@ -100,11 +100,11 @@ ole_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.le (get_local 3), (get_local 2)
+	f64.le push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end5:
@@ -117,11 +117,11 @@ ogt_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.gt (get_local 3), (get_local 2)
+	f64.gt push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -134,11 +134,11 @@ oge_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.ge (get_local 3), (get_local 2)
+	f64.ge push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end7:
@@ -151,19 +151,19 @@ ueq_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.eq (get_local 3), (get_local 2)
+	f64.eq push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f64.ne (get_local 2), (get_local 2)
+	f64.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f64.ne (get_local 3), (get_local 3)
+	f64.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end8:
@@ -176,19 +176,19 @@ one_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.ne (get_local 3), (get_local 2)
+	f64.ne push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f64.eq (get_local 2), (get_local 2)
+	f64.eq push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f64.eq (get_local 3), (get_local 3)
+	f64.eq push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.and (get_local 6), (get_local 5)
+	i32.and push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.and (get_local 4), (get_local 7)
+	i32.and push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end9:
@@ -201,19 +201,19 @@ ult_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.lt (get_local 3), (get_local 2)
+	f64.lt push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f64.ne (get_local 2), (get_local 2)
+	f64.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f64.ne (get_local 3), (get_local 3)
+	f64.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end10:
@@ -226,19 +226,19 @@ ule_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.le (get_local 3), (get_local 2)
+	f64.le push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f64.ne (get_local 2), (get_local 2)
+	f64.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f64.ne (get_local 3), (get_local 3)
+	f64.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end11:
@@ -251,19 +251,19 @@ ugt_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.gt (get_local 3), (get_local 2)
+	f64.gt push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f64.ne (get_local 2), (get_local 2)
+	f64.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f64.ne (get_local 3), (get_local 3)
+	f64.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end12:
@@ -276,19 +276,19 @@ uge_f64:
 	.param f64
 	.result i32
 	.local f64, f64, i32, i32, i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.ge (get_local 3), (get_local 2)
+	f64.ge push, (get_local 3), (get_local 2)
 	set_local 4, pop
-	f64.ne (get_local 2), (get_local 2)
+	f64.ne push, (get_local 2), (get_local 2)
 	set_local 5, pop
-	f64.ne (get_local 3), (get_local 3)
+	f64.ne push, (get_local 3), (get_local 3)
 	set_local 6, pop
-	i32.or (get_local 6), (get_local 5)
+	i32.or push, (get_local 6), (get_local 5)
 	set_local 7, pop
-	i32.or (get_local 4), (get_local 7)
+	i32.or push, (get_local 4), (get_local 7)
 	set_local 8, pop
 	return (get_local 8)
 func_end13:

--- a/prototype-wasmate/test/comparisons_i32.s
+++ b/prototype-wasmate/test/comparisons_i32.s
@@ -7,11 +7,11 @@ eq_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.eq (get_local 3), (get_local 2)
+	i32.eq push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end0:
@@ -24,11 +24,11 @@ ne_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.ne (get_local 3), (get_local 2)
+	i32.ne push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end1:
@@ -41,11 +41,11 @@ slt_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.lt_s (get_local 3), (get_local 2)
+	i32.lt_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -58,11 +58,11 @@ sle_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.le_s (get_local 3), (get_local 2)
+	i32.le_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -75,11 +75,11 @@ ult_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.lt_u (get_local 3), (get_local 2)
+	i32.lt_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end4:
@@ -92,11 +92,11 @@ ule_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.le_u (get_local 3), (get_local 2)
+	i32.le_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end5:
@@ -109,11 +109,11 @@ sgt_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.gt_s (get_local 3), (get_local 2)
+	i32.gt_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -126,11 +126,11 @@ sge_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.ge_s (get_local 3), (get_local 2)
+	i32.ge_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end7:
@@ -143,11 +143,11 @@ ugt_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.gt_u (get_local 3), (get_local 2)
+	i32.gt_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end8:
@@ -160,11 +160,11 @@ uge_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.ge_u (get_local 3), (get_local 2)
+	i32.ge_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end9:

--- a/prototype-wasmate/test/comparisons_i64.s
+++ b/prototype-wasmate/test/comparisons_i64.s
@@ -7,11 +7,11 @@ eq_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.eq (get_local 3), (get_local 2)
+	i64.eq push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end0:
@@ -24,11 +24,11 @@ ne_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.ne (get_local 3), (get_local 2)
+	i64.ne push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end1:
@@ -41,11 +41,11 @@ slt_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.lt_s (get_local 3), (get_local 2)
+	i64.lt_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -58,11 +58,11 @@ sle_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.le_s (get_local 3), (get_local 2)
+	i64.le_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -75,11 +75,11 @@ ult_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.lt_u (get_local 3), (get_local 2)
+	i64.lt_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end4:
@@ -92,11 +92,11 @@ ule_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.le_u (get_local 3), (get_local 2)
+	i64.le_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end5:
@@ -109,11 +109,11 @@ sgt_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.gt_s (get_local 3), (get_local 2)
+	i64.gt_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -126,11 +126,11 @@ sge_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.ge_s (get_local 3), (get_local 2)
+	i64.ge_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end7:
@@ -143,11 +143,11 @@ ugt_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.gt_u (get_local 3), (get_local 2)
+	i64.gt_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end8:
@@ -160,11 +160,11 @@ uge_i64:
 	.param i64
 	.result i32
 	.local i64, i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.ge_u (get_local 3), (get_local 2)
+	i64.ge_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end9:

--- a/prototype-wasmate/test/conv.s
+++ b/prototype-wasmate/test/conv.s
@@ -6,9 +6,9 @@ i32_wrap_i64:
 	.param i64
 	.result i32
 	.local i64, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.wrap/i64 (get_local 1)
+	i32.wrap/i64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end0:
@@ -20,9 +20,9 @@ i64_extend_s_i32:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.extend_s/i32 (get_local 1)
+	i64.extend_s/i32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end1:
@@ -34,9 +34,9 @@ i64_extend_u_i32:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.extend_u/i32 (get_local 1)
+	i64.extend_u/i32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end2:
@@ -48,9 +48,9 @@ i32_trunc_s_f32:
 	.param f32
 	.result i32
 	.local f32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.trunc_s/f32 (get_local 1)
+	i32.trunc_s/f32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end3:
@@ -62,9 +62,9 @@ i32_trunc_u_f32:
 	.param f32
 	.result i32
 	.local f32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.trunc_u/f32 (get_local 1)
+	i32.trunc_u/f32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end4:
@@ -76,9 +76,9 @@ i32_trunc_s_f64:
 	.param f64
 	.result i32
 	.local f64, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.trunc_s/f64 (get_local 1)
+	i32.trunc_s/f64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end5:
@@ -90,9 +90,9 @@ i32_trunc_u_f64:
 	.param f64
 	.result i32
 	.local f64, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.trunc_u/f64 (get_local 1)
+	i32.trunc_u/f64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end6:
@@ -104,9 +104,9 @@ i64_trunc_s_f32:
 	.param f32
 	.result i64
 	.local f32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.trunc_s/f32 (get_local 1)
+	i64.trunc_s/f32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end7:
@@ -118,9 +118,9 @@ i64_trunc_u_f32:
 	.param f32
 	.result i64
 	.local f32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.trunc_u/f32 (get_local 1)
+	i64.trunc_u/f32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end8:
@@ -132,9 +132,9 @@ i64_trunc_s_f64:
 	.param f64
 	.result i64
 	.local f64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.trunc_s/f64 (get_local 1)
+	i64.trunc_s/f64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end9:
@@ -146,9 +146,9 @@ i64_trunc_u_f64:
 	.param f64
 	.result i64
 	.local f64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.trunc_u/f64 (get_local 1)
+	i64.trunc_u/f64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end10:
@@ -160,9 +160,9 @@ f32_convert_s_i32:
 	.param i32
 	.result f32
 	.local i32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.convert_s/i32 (get_local 1)
+	f32.convert_s/i32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end11:
@@ -174,9 +174,9 @@ f32_convert_u_i32:
 	.param i32
 	.result f32
 	.local i32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.convert_u/i32 (get_local 1)
+	f32.convert_u/i32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end12:
@@ -188,9 +188,9 @@ f64_convert_s_i32:
 	.param i32
 	.result f64
 	.local i32, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.convert_s/i32 (get_local 1)
+	f64.convert_s/i32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end13:
@@ -202,9 +202,9 @@ f64_convert_u_i32:
 	.param i32
 	.result f64
 	.local i32, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.convert_u/i32 (get_local 1)
+	f64.convert_u/i32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end14:
@@ -216,9 +216,9 @@ f32_convert_s_i64:
 	.param i64
 	.result f32
 	.local i64, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.convert_s/i64 (get_local 1)
+	f32.convert_s/i64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end15:
@@ -230,9 +230,9 @@ f32_convert_u_i64:
 	.param i64
 	.result f32
 	.local i64, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.convert_u/i64 (get_local 1)
+	f32.convert_u/i64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end16:
@@ -244,9 +244,9 @@ f64_convert_s_i64:
 	.param i64
 	.result f64
 	.local i64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.convert_s/i64 (get_local 1)
+	f64.convert_s/i64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end17:
@@ -258,9 +258,9 @@ f64_convert_u_i64:
 	.param i64
 	.result f64
 	.local i64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.convert_u/i64 (get_local 1)
+	f64.convert_u/i64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end18:
@@ -272,9 +272,9 @@ f64_promote_f32:
 	.param f32
 	.result f64
 	.local f32, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.promote/f32 (get_local 1)
+	f64.promote/f32 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end19:
@@ -286,9 +286,9 @@ f32_demote_f64:
 	.param f64
 	.result f32
 	.local f64, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.demote/f64 (get_local 1)
+	f32.demote/f64 push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end20:

--- a/prototype-wasmate/test/cpus.s
+++ b/prototype-wasmate/test/cpus.s
@@ -7,7 +7,7 @@ f:                                      # @f
 	.result i32
 	.local i32
 # BB#0:
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
 	return (get_local 1)
 func_end0:

--- a/prototype-wasmate/test/dead-vreg.s
+++ b/prototype-wasmate/test/dead-vreg.s
@@ -8,59 +8,59 @@ foo:
 	.param i32
 	.local i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 	block $BB0_5
-	get_local 2
+	get_local push, 2
 	set_local 16, pop
-	i32.const 1
+	i32.const push, 1
 	set_local 17, pop
-	i32.lt_s (get_local 16), (get_local 17)
+	i32.lt_s push, (get_local 16), (get_local 17)
 	set_local 18, pop
 	br_if $BB0_5, (get_local 18)
-	get_local 1
+	get_local push, 1
 	set_local 15, pop
-	get_local 0
+	get_local push, 0
 	set_local 30, pop
-	i32.const 2
+	i32.const push, 2
 	set_local 20, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 19, pop
-	i32.shl (get_local 15), (get_local 20)
+	i32.shl push, (get_local 15), (get_local 20)
 	set_local 3, pop
-	get_local 19
+	get_local push, 19
 	set_local 31, pop
 BB0_2:
 	loop $BB0_5
 	block $BB0_4
-	i32.lt_s (get_local 15), (get_local 17)
+	i32.lt_s push, (get_local 15), (get_local 17)
 	set_local 23, pop
-	get_local 19
+	get_local push, 19
 	set_local 32, pop
-	get_local 30
+	get_local push, 30
 	set_local 33, pop
-	get_local 15
+	get_local push, 15
 	set_local 34, pop
 	br_if $BB0_4, (get_local 23)
 BB0_3:
 	loop $BB0_4
 	i32.store (get_local 33), (get_local 32)
-	i32.const -1
+	i32.const push, -1
 	set_local 24, pop
-	i32.add (get_local 34), (get_local 24)
+	i32.add push, (get_local 34), (get_local 24)
 	set_local 34, pop
-	i32.const 4
+	i32.const push, 4
 	set_local 25, pop
-	i32.add (get_local 33), (get_local 25)
+	i32.add push, (get_local 33), (get_local 25)
 	set_local 33, pop
-	i32.add (get_local 32), (get_local 31)
+	i32.add push, (get_local 32), (get_local 31)
 	set_local 32, pop
-	i32.ne (get_local 34), (get_local 19)
+	i32.ne push, (get_local 34), (get_local 19)
 	set_local 27, pop
 	br_if $BB0_3, (get_local 27)
 BB0_4:
-	i32.add (get_local 31), (get_local 17)
+	i32.add push, (get_local 31), (get_local 17)
 	set_local 31, pop
-	i32.add (get_local 30), (get_local 3)
+	i32.add push, (get_local 30), (get_local 3)
 	set_local 30, pop
-	i32.ne (get_local 31), (get_local 16)
+	i32.ne push, (get_local 31), (get_local 16)
 	set_local 29, pop
 	br_if $BB0_2, (get_local 29)
 BB0_5:

--- a/prototype-wasmate/test/exit.s
+++ b/prototype-wasmate/test/exit.s
@@ -6,7 +6,7 @@ main:                                   # @main
 	.result i32
 	.local i32
 # BB#0:                                 # %entry
-	i32.const 0
+	i32.const push, 0
 	set_local 0, pop
 	call $exit, (get_local 0)
 func_end0:

--- a/prototype-wasmate/test/f32.s
+++ b/prototype-wasmate/test/f32.s
@@ -7,11 +7,11 @@ fadd32:
 	.param f32
 	.result f32
 	.local f32, f32, f32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.add (get_local 3), (get_local 2)
+	f32.add push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end0:
@@ -24,11 +24,11 @@ fsub32:
 	.param f32
 	.result f32
 	.local f32, f32, f32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.sub (get_local 3), (get_local 2)
+	f32.sub push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end1:
@@ -41,11 +41,11 @@ fmul32:
 	.param f32
 	.result f32
 	.local f32, f32, f32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.mul (get_local 3), (get_local 2)
+	f32.mul push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -58,11 +58,11 @@ fdiv32:
 	.param f32
 	.result f32
 	.local f32, f32, f32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.div (get_local 3), (get_local 2)
+	f32.div push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -74,9 +74,9 @@ fabs32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.abs (get_local 1)
+	f32.abs push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end4:
@@ -88,9 +88,9 @@ fneg32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.neg (get_local 1)
+	f32.neg push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end5:
@@ -103,11 +103,11 @@ copysign32:
 	.param f32
 	.result f32
 	.local f32, f32, f32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f32.copysign (get_local 3), (get_local 2)
+	f32.copysign push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -119,9 +119,9 @@ sqrt32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.sqrt (get_local 1)
+	f32.sqrt push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end7:
@@ -133,9 +133,9 @@ ceil32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.ceil (get_local 1)
+	f32.ceil push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end8:
@@ -147,9 +147,9 @@ floor32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.floor (get_local 1)
+	f32.floor push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end9:
@@ -161,9 +161,9 @@ trunc32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.trunc (get_local 1)
+	f32.trunc push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end10:
@@ -175,9 +175,9 @@ nearest32:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.nearest (get_local 1)
+	f32.nearest push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end11:
@@ -189,9 +189,9 @@ nearest32_via_rint:
 	.param f32
 	.result f32
 	.local f32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.nearest (get_local 1)
+	f32.nearest push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end12:

--- a/prototype-wasmate/test/f64.s
+++ b/prototype-wasmate/test/f64.s
@@ -7,11 +7,11 @@ fadd64:
 	.param f64
 	.result f64
 	.local f64, f64, f64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.add (get_local 3), (get_local 2)
+	f64.add push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end0:
@@ -24,11 +24,11 @@ fsub64:
 	.param f64
 	.result f64
 	.local f64, f64, f64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.sub (get_local 3), (get_local 2)
+	f64.sub push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end1:
@@ -41,11 +41,11 @@ fmul64:
 	.param f64
 	.result f64
 	.local f64, f64, f64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.mul (get_local 3), (get_local 2)
+	f64.mul push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -58,11 +58,11 @@ fdiv64:
 	.param f64
 	.result f64
 	.local f64, f64, f64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.div (get_local 3), (get_local 2)
+	f64.div push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -74,9 +74,9 @@ fabs64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.abs (get_local 1)
+	f64.abs push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end4:
@@ -88,9 +88,9 @@ fneg64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.neg (get_local 1)
+	f64.neg push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end5:
@@ -103,11 +103,11 @@ copysign64:
 	.param f64
 	.result f64
 	.local f64, f64, f64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	f64.copysign (get_local 3), (get_local 2)
+	f64.copysign push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -119,9 +119,9 @@ sqrt64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.sqrt (get_local 1)
+	f64.sqrt push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end7:
@@ -133,9 +133,9 @@ ceil64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.ceil (get_local 1)
+	f64.ceil push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end8:
@@ -147,9 +147,9 @@ floor64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.floor (get_local 1)
+	f64.floor push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end9:
@@ -161,9 +161,9 @@ trunc64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.trunc (get_local 1)
+	f64.trunc push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end10:
@@ -175,9 +175,9 @@ nearest64:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.nearest (get_local 1)
+	f64.nearest push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end11:
@@ -189,9 +189,9 @@ nearest64_via_rint:
 	.param f64
 	.result f64
 	.local f64, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.nearest (get_local 1)
+	f64.nearest push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end12:

--- a/prototype-wasmate/test/fast-isel.s
+++ b/prototype-wasmate/test/fast-isel.s
@@ -5,7 +5,7 @@
 immediate_f32:
 	.result f32
 	.local f32
-	f32.const 0x1.4p1
+	f32.const push, 0x1.4p1
 	set_local 0, pop
 	return (get_local 0)
 func_end0:
@@ -16,7 +16,7 @@ func_end0:
 immediate_f64:
 	.result f64
 	.local f64
-	f64.const 0x1.4p1
+	f64.const push, 0x1.4p1
 	set_local 0, pop
 	return (get_local 0)
 func_end1:

--- a/prototype-wasmate/test/func.s
+++ b/prototype-wasmate/test/func.s
@@ -12,7 +12,7 @@ func_end0:
 f1:
 	.result i32
 	.local i32
-	i32.const 0
+	i32.const push, 0
 	set_local 0, pop
 	return (get_local 0)
 func_end1:
@@ -25,7 +25,7 @@ f2:
 	.param f32
 	.result i32
 	.local i32
-	i32.const 0
+	i32.const push, 0
 	set_local 2, pop
 	return (get_local 2)
 func_end2:

--- a/prototype-wasmate/test/i32.s
+++ b/prototype-wasmate/test/i32.s
@@ -7,11 +7,11 @@ add32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.add (get_local 3), (get_local 2)
+	i32.add push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end0:
@@ -24,11 +24,11 @@ sub32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.sub (get_local 3), (get_local 2)
+	i32.sub push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end1:
@@ -41,11 +41,11 @@ mul32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.mul (get_local 3), (get_local 2)
+	i32.mul push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -58,11 +58,11 @@ sdiv32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.div_s (get_local 3), (get_local 2)
+	i32.div_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -75,11 +75,11 @@ udiv32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.div_u (get_local 3), (get_local 2)
+	i32.div_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end4:
@@ -92,11 +92,11 @@ srem32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.rem_s (get_local 3), (get_local 2)
+	i32.rem_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end5:
@@ -109,11 +109,11 @@ urem32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.rem_u (get_local 3), (get_local 2)
+	i32.rem_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -126,11 +126,11 @@ and32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.and (get_local 3), (get_local 2)
+	i32.and push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end7:
@@ -143,11 +143,11 @@ or32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.or (get_local 3), (get_local 2)
+	i32.or push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end8:
@@ -160,11 +160,11 @@ xor32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.xor (get_local 3), (get_local 2)
+	i32.xor push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end9:
@@ -177,11 +177,11 @@ shl32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.shl (get_local 3), (get_local 2)
+	i32.shl push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end10:
@@ -194,11 +194,11 @@ shr32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.shr_u (get_local 3), (get_local 2)
+	i32.shr_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end11:
@@ -211,11 +211,11 @@ sar32:
 	.param i32
 	.result i32
 	.local i32, i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i32.shr_s (get_local 3), (get_local 2)
+	i32.shr_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end12:
@@ -227,9 +227,9 @@ clz32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.clz (get_local 1)
+	i32.clz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end13:
@@ -241,9 +241,9 @@ clz32_zero_undef:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.clz (get_local 1)
+	i32.clz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end14:
@@ -255,9 +255,9 @@ ctz32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.ctz (get_local 1)
+	i32.ctz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end15:
@@ -269,9 +269,9 @@ ctz32_zero_undef:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.ctz (get_local 1)
+	i32.ctz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end16:
@@ -283,9 +283,9 @@ popcnt32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.popcnt (get_local 1)
+	i32.popcnt push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end17:

--- a/prototype-wasmate/test/i64.s
+++ b/prototype-wasmate/test/i64.s
@@ -7,11 +7,11 @@ add64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.add (get_local 3), (get_local 2)
+	i64.add push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end0:
@@ -24,11 +24,11 @@ sub64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.sub (get_local 3), (get_local 2)
+	i64.sub push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end1:
@@ -41,11 +41,11 @@ mul64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.mul (get_local 3), (get_local 2)
+	i64.mul push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end2:
@@ -58,11 +58,11 @@ sdiv64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.div_s (get_local 3), (get_local 2)
+	i64.div_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end3:
@@ -75,11 +75,11 @@ udiv64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.div_u (get_local 3), (get_local 2)
+	i64.div_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end4:
@@ -92,11 +92,11 @@ srem64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.rem_s (get_local 3), (get_local 2)
+	i64.rem_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end5:
@@ -109,11 +109,11 @@ urem64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.rem_u (get_local 3), (get_local 2)
+	i64.rem_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end6:
@@ -126,11 +126,11 @@ and64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.and (get_local 3), (get_local 2)
+	i64.and push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end7:
@@ -143,11 +143,11 @@ or64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.or (get_local 3), (get_local 2)
+	i64.or push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end8:
@@ -160,11 +160,11 @@ xor64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.xor (get_local 3), (get_local 2)
+	i64.xor push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end9:
@@ -177,11 +177,11 @@ shl64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.shl (get_local 3), (get_local 2)
+	i64.shl push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end10:
@@ -194,11 +194,11 @@ shr64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.shr_u (get_local 3), (get_local 2)
+	i64.shr_u push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end11:
@@ -211,11 +211,11 @@ sar64:
 	.param i64
 	.result i64
 	.local i64, i64, i64
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	i64.shr_s (get_local 3), (get_local 2)
+	i64.shr_s push, (get_local 3), (get_local 2)
 	set_local 4, pop
 	return (get_local 4)
 func_end12:
@@ -227,9 +227,9 @@ clz64:
 	.param i64
 	.result i64
 	.local i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.clz (get_local 1)
+	i64.clz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end13:
@@ -241,9 +241,9 @@ clz64_zero_undef:
 	.param i64
 	.result i64
 	.local i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.clz (get_local 1)
+	i64.clz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end14:
@@ -255,9 +255,9 @@ ctz64:
 	.param i64
 	.result i64
 	.local i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.ctz (get_local 1)
+	i64.ctz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end15:
@@ -269,9 +269,9 @@ ctz64_zero_undef:
 	.param i64
 	.result i64
 	.local i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.ctz (get_local 1)
+	i64.ctz push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end16:
@@ -283,9 +283,9 @@ popcnt64:
 	.param i64
 	.result i64
 	.local i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.popcnt (get_local 1)
+	i64.popcnt push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end17:

--- a/prototype-wasmate/test/immediates.s
+++ b/prototype-wasmate/test/immediates.s
@@ -5,7 +5,7 @@
 zero_i32:
 	.result i32
 	.local i32
-	i32.const 0
+	i32.const push, 0
 	set_local 0, pop
 	return (get_local 0)
 func_end0:
@@ -16,7 +16,7 @@ func_end0:
 one_i32:
 	.result i32
 	.local i32
-	i32.const 1
+	i32.const push, 1
 	set_local 0, pop
 	return (get_local 0)
 func_end1:
@@ -27,7 +27,7 @@ func_end1:
 max_i32:
 	.result i32
 	.local i32
-	i32.const 2147483647
+	i32.const push, 2147483647
 	set_local 0, pop
 	return (get_local 0)
 func_end2:
@@ -38,7 +38,7 @@ func_end2:
 min_i32:
 	.result i32
 	.local i32
-	i32.const -2147483648
+	i32.const push, -2147483648
 	set_local 0, pop
 	return (get_local 0)
 func_end3:
@@ -49,7 +49,7 @@ func_end3:
 zero_i64:
 	.result i64
 	.local i64
-	i64.const 0
+	i64.const push, 0
 	set_local 0, pop
 	return (get_local 0)
 func_end4:
@@ -60,7 +60,7 @@ func_end4:
 one_i64:
 	.result i64
 	.local i64
-	i64.const 1
+	i64.const push, 1
 	set_local 0, pop
 	return (get_local 0)
 func_end5:
@@ -71,7 +71,7 @@ func_end5:
 max_i64:
 	.result i64
 	.local i64
-	i64.const 9223372036854775807
+	i64.const push, 9223372036854775807
 	set_local 0, pop
 	return (get_local 0)
 func_end6:
@@ -82,7 +82,7 @@ func_end6:
 min_i64:
 	.result i64
 	.local i64
-	i64.const -9223372036854775808
+	i64.const push, -9223372036854775808
 	set_local 0, pop
 	return (get_local 0)
 func_end7:
@@ -93,7 +93,7 @@ func_end7:
 negzero_f32:
 	.result f32
 	.local f32
-	f32.const -0x0p0
+	f32.const push, -0x0p0
 	set_local 0, pop
 	return (get_local 0)
 func_end8:
@@ -104,7 +104,7 @@ func_end8:
 zero_f32:
 	.result f32
 	.local f32
-	f32.const 0x0p0
+	f32.const push, 0x0p0
 	set_local 0, pop
 	return (get_local 0)
 func_end9:
@@ -115,7 +115,7 @@ func_end9:
 one_f32:
 	.result f32
 	.local f32
-	f32.const 0x1p0
+	f32.const push, 0x1p0
 	set_local 0, pop
 	return (get_local 0)
 func_end10:
@@ -126,7 +126,7 @@ func_end10:
 two_f32:
 	.result f32
 	.local f32
-	f32.const 0x1p1
+	f32.const push, 0x1p1
 	set_local 0, pop
 	return (get_local 0)
 func_end11:
@@ -137,7 +137,7 @@ func_end11:
 nan_f32:
 	.result f32
 	.local f32
-	f32.const nan
+	f32.const push, nan
 	set_local 0, pop
 	return (get_local 0)
 func_end12:
@@ -148,7 +148,7 @@ func_end12:
 negnan_f32:
 	.result f32
 	.local f32
-	f32.const -nan
+	f32.const push, -nan
 	set_local 0, pop
 	return (get_local 0)
 func_end13:
@@ -159,7 +159,7 @@ func_end13:
 inf_f32:
 	.result f32
 	.local f32
-	f32.const infinity
+	f32.const push, infinity
 	set_local 0, pop
 	return (get_local 0)
 func_end14:
@@ -170,7 +170,7 @@ func_end14:
 neginf_f32:
 	.result f32
 	.local f32
-	f32.const -infinity
+	f32.const push, -infinity
 	set_local 0, pop
 	return (get_local 0)
 func_end15:
@@ -181,7 +181,7 @@ func_end15:
 negzero_f64:
 	.result f64
 	.local f64
-	f64.const -0x0p0
+	f64.const push, -0x0p0
 	set_local 0, pop
 	return (get_local 0)
 func_end16:
@@ -192,7 +192,7 @@ func_end16:
 zero_f64:
 	.result f64
 	.local f64
-	f64.const 0x0p0
+	f64.const push, 0x0p0
 	set_local 0, pop
 	return (get_local 0)
 func_end17:
@@ -203,7 +203,7 @@ func_end17:
 one_f64:
 	.result f64
 	.local f64
-	f64.const 0x1p0
+	f64.const push, 0x1p0
 	set_local 0, pop
 	return (get_local 0)
 func_end18:
@@ -214,7 +214,7 @@ func_end18:
 two_f64:
 	.result f64
 	.local f64
-	f64.const 0x1p1
+	f64.const push, 0x1p1
 	set_local 0, pop
 	return (get_local 0)
 func_end19:
@@ -225,7 +225,7 @@ func_end19:
 nan_f64:
 	.result f64
 	.local f64
-	f64.const nan
+	f64.const push, nan
 	set_local 0, pop
 	return (get_local 0)
 func_end20:
@@ -236,7 +236,7 @@ func_end20:
 negnan_f64:
 	.result f64
 	.local f64
-	f64.const -nan
+	f64.const push, -nan
 	set_local 0, pop
 	return (get_local 0)
 func_end21:
@@ -247,7 +247,7 @@ func_end21:
 inf_f64:
 	.result f64
 	.local f64
-	f64.const infinity
+	f64.const push, infinity
 	set_local 0, pop
 	return (get_local 0)
 func_end22:
@@ -258,7 +258,7 @@ func_end22:
 neginf_f64:
 	.result f64
 	.local f64
-	f64.const -infinity
+	f64.const push, -infinity
 	set_local 0, pop
 	return (get_local 0)
 func_end23:

--- a/prototype-wasmate/test/import.s
+++ b/prototype-wasmate/test/import.s
@@ -6,13 +6,13 @@ f:
 	.param i32
 	.param f32
 	.local f32, i32, i32, f32
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	call $printi, (get_local 3)
+	call $printi, push, (get_local 3)
 	set_local 4, pop
-	call $printf, (get_local 2)
+	call $printf, push, (get_local 2)
 	set_local 5, pop
 	call $printv
 	return

--- a/prototype-wasmate/test/load-ext.s
+++ b/prototype-wasmate/test/load-ext.s
@@ -6,9 +6,9 @@ sext_i8_i32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load8_s (get_local 1)
+	i32.load8_s push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end0:
@@ -20,9 +20,9 @@ zext_i8_i32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load8_u (get_local 1)
+	i32.load8_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end1:
@@ -34,9 +34,9 @@ sext_i16_i32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load16_s (get_local 1)
+	i32.load16_s push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end2:
@@ -48,9 +48,9 @@ zext_i16_i32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load16_u (get_local 1)
+	i32.load16_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end3:
@@ -62,9 +62,9 @@ sext_i8_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load8_s (get_local 1)
+	i64.load8_s push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end4:
@@ -76,9 +76,9 @@ zext_i8_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load8_u (get_local 1)
+	i64.load8_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end5:
@@ -90,9 +90,9 @@ sext_i16_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load16_s (get_local 1)
+	i64.load16_s push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end6:
@@ -104,9 +104,9 @@ zext_i16_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load16_u (get_local 1)
+	i64.load16_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end7:
@@ -118,9 +118,9 @@ sext_i32_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load32_s (get_local 1)
+	i64.load32_s push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end8:
@@ -132,9 +132,9 @@ zext_i32_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load32_u (get_local 1)
+	i64.load32_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end9:

--- a/prototype-wasmate/test/load-store-i1.s
+++ b/prototype-wasmate/test/load-store-i1.s
@@ -6,9 +6,9 @@ load_u_i1_i32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load8_u (get_local 1)
+	i32.load8_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end0:
@@ -20,15 +20,15 @@ load_s_i1_i32:
 	.param i32
 	.result i32
 	.local i32, i32, i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load8_u (get_local 1)
+	i32.load8_u push, (get_local 1)
 	set_local 2, pop
-	i32.const 31
+	i32.const push, 31
 	set_local 3, pop
-	i32.shl (get_local 2), (get_local 3)
+	i32.shl push, (get_local 2), (get_local 3)
 	set_local 4, pop
-	i32.shr_s (get_local 4), (get_local 3)
+	i32.shr_s push, (get_local 4), (get_local 3)
 	set_local 5, pop
 	return (get_local 5)
 func_end1:
@@ -40,9 +40,9 @@ load_u_i1_i64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load8_u (get_local 1)
+	i64.load8_u push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end2:
@@ -54,15 +54,15 @@ load_s_i1_i64:
 	.param i32
 	.result i64
 	.local i32, i64, i64, i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load8_u (get_local 1)
+	i64.load8_u push, (get_local 1)
 	set_local 2, pop
-	i64.const 63
+	i64.const push, 63
 	set_local 3, pop
-	i64.shl (get_local 2), (get_local 3)
+	i64.shl push, (get_local 2), (get_local 3)
 	set_local 4, pop
-	i64.shr_s (get_local 4), (get_local 3)
+	i64.shr_s push, (get_local 4), (get_local 3)
 	set_local 5, pop
 	return (get_local 5)
 func_end3:
@@ -74,13 +74,13 @@ store_i32_i1:
 	.param i32
 	.param i32
 	.local i32, i32, i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i32.const 1
+	i32.const push, 1
 	set_local 4, pop
-	i32.and (get_local 3), (get_local 4)
+	i32.and push, (get_local 3), (get_local 4)
 	set_local 5, pop
 	i32.store8 (get_local 2), (get_local 5)
 	return
@@ -93,13 +93,13 @@ store_i64_i1:
 	.param i32
 	.param i64
 	.local i32, i64, i64, i64
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	get_local 1
+	get_local push, 1
 	set_local 3, pop
-	i64.const 1
+	i64.const push, 1
 	set_local 4, pop
-	i64.and (get_local 3), (get_local 4)
+	i64.and push, (get_local 3), (get_local 4)
 	set_local 5, pop
 	i64.store8 (get_local 2), (get_local 5)
 	return

--- a/prototype-wasmate/test/load.s
+++ b/prototype-wasmate/test/load.s
@@ -6,9 +6,9 @@ ldi32:
 	.param i32
 	.result i32
 	.local i32, i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i32.load (get_local 1)
+	i32.load push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end0:
@@ -20,9 +20,9 @@ ldi64:
 	.param i32
 	.result i64
 	.local i32, i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.load (get_local 1)
+	i64.load push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end1:
@@ -34,9 +34,9 @@ ldf32:
 	.param i32
 	.result f32
 	.local i32, f32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f32.load (get_local 1)
+	f32.load push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end2:
@@ -48,9 +48,9 @@ ldf64:
 	.param i32
 	.result f64
 	.local i32, f64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	f64.load (get_local 1)
+	f64.load push, (get_local 1)
 	set_local 2, pop
 	return (get_local 2)
 func_end3:

--- a/prototype-wasmate/test/memory-addr32.s
+++ b/prototype-wasmate/test/memory-addr32.s
@@ -5,7 +5,7 @@
 memory_size:
 	.result i32
 	.local i32
-	i32.memory_size
+	i32.memory_size push
 	set_local 0, pop
 	return (get_local 0)
 func_end0:
@@ -16,7 +16,7 @@ func_end0:
 grow_memory:
 	.param i32
 	.local i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
 	i32.grow_memory (get_local 1)
 	return

--- a/prototype-wasmate/test/memory-addr64.s
+++ b/prototype-wasmate/test/memory-addr64.s
@@ -5,7 +5,7 @@
 memory_size:
 	.result i64
 	.local i64
-	i64.memory_size
+	i64.memory_size push
 	set_local 0, pop
 	return (get_local 0)
 func_end0:
@@ -16,7 +16,7 @@ func_end0:
 grow_memory:
 	.param i64
 	.local i64
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
 	i64.grow_memory (get_local 1)
 	return

--- a/prototype-wasmate/test/phi.s
+++ b/prototype-wasmate/test/phi.s
@@ -7,16 +7,16 @@ test0:
 	.result i32
 	.local i32, i32, i32, i32, i32, i32, i32
 	block $BB0_2
-	get_local 0
+	get_local push, 0
 	set_local 7, pop
-	i32.const -1
+	i32.const push, -1
 	set_local 4, pop
-	i32.gt_s (get_local 7), (get_local 4)
+	i32.gt_s push, (get_local 7), (get_local 4)
 	set_local 5, pop
 	br_if $BB0_2, (get_local 5)
-	i32.const 3
+	i32.const push, 3
 	set_local 6, pop
-	i32.div_s (get_local 7), (get_local 6)
+	i32.div_s push, (get_local 7), (get_local 6)
 	set_local 7, pop
 BB0_2:
 	return (get_local 7)
@@ -29,27 +29,27 @@ test1:
 	.param i32
 	.result i32
 	.local i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
-	i32.const 1
+	i32.const push, 1
 	set_local 7, pop
-	i32.const 0
+	i32.const push, 0
 	set_local 10, pop
-	get_local 0
+	get_local push, 0
 	set_local 5, pop
-	get_local 7
+	get_local push, 7
 	set_local 11, pop
-	get_local 10
+	get_local push, 10
 	set_local 12, pop
 BB1_1:
 	loop $BB1_2
-	get_local 11
+	get_local push, 11
 	set_local 2, pop
-	get_local 10
+	get_local push, 10
 	set_local 11, pop
-	i32.add (get_local 12), (get_local 7)
+	i32.add push, (get_local 12), (get_local 7)
 	set_local 12, pop
-	i32.lt_s (get_local 12), (get_local 5)
+	i32.lt_s push, (get_local 12), (get_local 5)
 	set_local 9, pop
-	get_local 2
+	get_local push, 2
 	set_local 10, pop
 	br_if $BB1_1, (get_local 9)
 	return (get_local 11)

--- a/prototype-wasmate/test/return-int32.s
+++ b/prototype-wasmate/test/return-int32.s
@@ -6,7 +6,7 @@ return_i32:
 	.param i32
 	.result i32
 	.local i32
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
 	return (get_local 1)
 func_end0:

--- a/prototype-wasmate/test/store-trunc.s
+++ b/prototype-wasmate/test/store-trunc.s
@@ -6,9 +6,9 @@ trunc_i8_i32:
 	.param i32
 	.param i32
 	.local i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i32.store8 (get_local 3), (get_local 2)
 	return
@@ -21,9 +21,9 @@ trunc_i16_i32:
 	.param i32
 	.param i32
 	.local i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i32.store16 (get_local 3), (get_local 2)
 	return
@@ -36,9 +36,9 @@ trunc_i8_i64:
 	.param i32
 	.param i64
 	.local i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i64.store8 (get_local 3), (get_local 2)
 	return
@@ -51,9 +51,9 @@ trunc_i16_i64:
 	.param i32
 	.param i64
 	.local i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i64.store16 (get_local 3), (get_local 2)
 	return
@@ -66,9 +66,9 @@ trunc_i32_i64:
 	.param i32
 	.param i64
 	.local i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i64.store32 (get_local 3), (get_local 2)
 	return

--- a/prototype-wasmate/test/store.s
+++ b/prototype-wasmate/test/store.s
@@ -6,9 +6,9 @@ sti32:
 	.param i32
 	.param i32
 	.local i32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i32.store (get_local 3), (get_local 2)
 	return
@@ -21,9 +21,9 @@ sti64:
 	.param i32
 	.param i64
 	.local i64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	i64.store (get_local 3), (get_local 2)
 	return
@@ -36,9 +36,9 @@ stf32:
 	.param i32
 	.param f32
 	.local f32, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	f32.store (get_local 3), (get_local 2)
 	return
@@ -51,9 +51,9 @@ stf64:
 	.param i32
 	.param f64
 	.local f64, i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
-	get_local 0
+	get_local push, 0
 	set_local 3, pop
 	f64.store (get_local 3), (get_local 2)
 	return

--- a/prototype-wasmate/test/switch.s
+++ b/prototype-wasmate/test/switch.s
@@ -12,11 +12,11 @@ bar32:
 	block $BB0_4
 	block $BB0_3
 	block $BB0_2
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
-	i32.const 23
+	i32.const push, 23
 	set_local 3, pop
-	i32.gt_u (get_local 2), (get_local 3)
+	i32.gt_u push, (get_local 2), (get_local 3)
 	set_local 4, pop
 	br_if $BB0_8, (get_local 4)
 	i32.switch (get_local 2), $BB0_2, $BB0_2, $BB0_2, $BB0_2, $BB0_2, $BB0_2, $BB0_2, $BB0_2, $BB0_3, $BB0_3, $BB0_3, $BB0_3, $BB0_3, $BB0_3, $BB0_3, $BB0_3, $BB0_4, $BB0_4, $BB0_4, $BB0_4, $BB0_4, $BB0_4, $BB0_5, $BB0_6, $BB0_7
@@ -54,14 +54,14 @@ bar64:
 	block $BB1_4
 	block $BB1_3
 	block $BB1_2
-	get_local 0
+	get_local push, 0
 	set_local 1, pop
-	i64.const 23
+	i64.const push, 23
 	set_local 3, pop
-	i64.gt_u (get_local 1), (get_local 3)
+	i64.gt_u push, (get_local 1), (get_local 3)
 	set_local 4, pop
 	br_if $BB1_8, (get_local 4)
-	i32.wrap/i64 (get_local 1)
+	i32.wrap/i64 push, (get_local 1)
 	set_local 2, pop
 	i32.switch (get_local 2), $BB1_2, $BB1_2, $BB1_2, $BB1_2, $BB1_2, $BB1_2, $BB1_2, $BB1_2, $BB1_3, $BB1_3, $BB1_3, $BB1_3, $BB1_3, $BB1_3, $BB1_3, $BB1_3, $BB1_4, $BB1_4, $BB1_4, $BB1_4, $BB1_4, $BB1_4, $BB1_5, $BB1_6, $BB1_7
 BB1_2:

--- a/prototype-wasmate/test/unused-argument.s
+++ b/prototype-wasmate/test/unused-argument.s
@@ -7,7 +7,7 @@ unused_first:
 	.param i32
 	.result i32
 	.local i32
-	get_local 1
+	get_local push, 1
 	set_local 2, pop
 	return (get_local 2)
 func_end0:
@@ -20,7 +20,7 @@ unused_second:
 	.param i32
 	.result i32
 	.local i32
-	get_local 0
+	get_local push, 0
 	set_local 2, pop
 	return (get_local 2)
 func_end1:

--- a/prototype-wasmate/wasmate.py
+++ b/prototype-wasmate/wasmate.py
@@ -302,7 +302,7 @@ def sexprify(command, args):
     s = '(' + command
     if len(args) != 0:
         s += ' '
-    s += ' '.join([resolve_label(arg) for arg in args])
+    s += ' '.join([resolve_label(arg) for arg in args if arg != 'push'])
     s += ')'
     return s
 
@@ -320,10 +320,6 @@ class TextPassHandler(PassHandler):
         if current_section == ".text":
             if current_function is not None:
                 # Label inside a function.
-
-                # Flush the expression stack before every label.
-                self.handle_void_call()
-
                 if labelname.startswith('func_end'):
                     pass
                 else:
@@ -339,16 +335,7 @@ class TextPassHandler(PassHandler):
                 out.write_line('(func $' + labelname)
                 out.indent()
 
-    def handle_void_call(self):
-        if len(self.expr_stack) != 0 and self.expr_stack[0].startswith('(call'):
-            out.write_line(self.expr_stack.pop())
-
     def handle_mnemonic(self, command, args):
-        # Hack: We don't know call signatures, so we don't know that void calls
-        # don't push anything onto the stack.
-        if command != 'set_local':
-            self.handle_void_call()
-
         # TODO(binji): LLVM outputs types for some commands that shouldn't have
         # them. Fix this upstream.
         split = command.split('.')
@@ -372,12 +359,21 @@ class TextPassHandler(PassHandler):
             assert len(self.expr_stack) == 0
         elif (command in ['br_if', 'br', 'switch', 'return', 'grow_memory'] or
               'store' in command):
+            assert not 'push' in args
             out.write_line(sexprify(command, args))
             assert len(self.expr_stack) == 0
         elif command == 'call' and args[0] in import_funs:
-            self.expr_stack.append(sexprify('call_import', args))
+            line = sexprify('call_import', args)
+            if 'push' in args:
+                self.expr_stack.append(line)
+            else:
+                out.write_line(line)
         else:
-            self.expr_stack.append(sexprify(command, args))
+            line = sexprify(command, args)
+            if 'push' in args:
+                self.expr_stack.append(line)
+            else:
+                out.write_line(line)
 
 
 def do_pass(handler, all_lines):

--- a/prototype-wasmate/wasmate.py
+++ b/prototype-wasmate/wasmate.py
@@ -359,7 +359,7 @@ class TextPassHandler(PassHandler):
             assert len(self.expr_stack) == 0
         elif (command in ['br_if', 'br', 'switch', 'return', 'grow_memory'] or
               'store' in command):
-            assert not 'push' in args
+            assert 'push' not in args
             out.write_line(sexprify(command, args))
             assert len(self.expr_stack) == 0
         elif command == 'call' and args[0] in import_funs:


### PR DESCRIPTION
This is accompanied by http://reviews.llvm.org/D14402 on the LLVM side.

It creates an explicit "push", which balances out the explicit "pop". This eliminates the need for strange special-casing of calls that return void in wasmate.py.

This is one step of many in a larger evolution of how we handle expressions.